### PR TITLE
Adds dosfstools to required packages

### DIFF
--- a/install-debian
+++ b/install-debian
@@ -32,7 +32,7 @@ do_prep () {
 
 	git submodule update --init
 
-	PACKAGES="debootstrap pigz"
+	PACKAGES="debootstrap pigz dosfstools"
 	[ ! -z "$CRYPT" ] && PACKAGES="$PACKAGES cryptsetup"
 	sudo apt-get install -y $PACKAGES
 }


### PR DESCRIPTION
Kinda simple, script requires `mkfs.vfat` which is in `dosfstools`.

Closes #18

(Created via web PR, for speed)