### PR TITLE
Installer fixes

### DIFF
--- a/etc/apt/sources.list.sid
+++ b/etc/apt/sources.list.sid
@@ -1,0 +1,2 @@
+deb http://deb.debian.org/debian sid main
+# deb-src http://deb.debian.org/debian sid main

--- a/etc/apt/sources.list.unstable
+++ b/etc/apt/sources.list.unstable
@@ -1,0 +1,2 @@
+deb http://deb.debian.org/debian unstable main
+# deb-src http://deb.debian.org/debian unstable main

--- a/install-debian
+++ b/install-debian
@@ -304,7 +304,7 @@ do_all () {
 ARCH=arm64
 RELEASE=bullseye
 SYSIMAGE="${PWD}/sysimage"
-MMCBLK="$(readlink -f /dev/disk/by-path/platform-fe320000.dwmmc)"
+MMCBLK="$(readlink -f /dev/disk/by-path/platform-fe320000.*mmc)"
 
 # For now we have *very* simple argument processing (similar to make)
 unset DO

--- a/install-debian
+++ b/install-debian
@@ -198,7 +198,8 @@ do_kernel () {
 	cat etc/default/u-boot.append | sudo tee -a ${SYSIMAGE}/etc/default/u-boot > /dev/null
 	cat etc/initramfs-tools/modules.append | sudo tee -a ${SYSIMAGE}/etc/initramfs-tools/modules > /dev/null
 	sudo install -m644 etc/initramfs-tools/conf.d/* ${SYSIMAGE}/etc/initramfs-tools/conf.d/
-        if -f etc/apt/sources.list.d/kernel-obs.list.${RELEASE}; then
+        if [ -f etc/apt/sources.list.d/kernel-obs.list.${RELEASE} ]
+	then
           sudo install -m644 etc/apt/sources.list.d/kernel-obs.list.${RELEASE} ${SYSIMAGE}/etc/apt/sources.list.d/kernel-obs.list
         else
           # Use the bullseye kernel for releases we don't know about.

--- a/install-debian
+++ b/install-debian
@@ -198,7 +198,12 @@ do_kernel () {
 	cat etc/default/u-boot.append | sudo tee -a ${SYSIMAGE}/etc/default/u-boot > /dev/null
 	cat etc/initramfs-tools/modules.append | sudo tee -a ${SYSIMAGE}/etc/initramfs-tools/modules > /dev/null
 	sudo install -m644 etc/initramfs-tools/conf.d/* ${SYSIMAGE}/etc/initramfs-tools/conf.d/
-	sudo install -m644 etc/apt/sources.list.d/kernel-obs.list.${RELEASE} ${SYSIMAGE}/etc/apt/sources.list.d/kernel-obs.list
+        if -f etc/apt/sources.list.d/kernel-obs.list.${RELEASE}; then
+          sudo install -m644 etc/apt/sources.list.d/kernel-obs.list.${RELEASE} ${SYSIMAGE}/etc/apt/sources.list.d/kernel-obs.list
+        else
+          # Use the bullseye kernel for releases we don't know about.
+          sudo install -m644 etc/apt/sources.list.d/kernel-obs.list.bullseye ${SYSIMAGE}/etc/apt/sources.list.d/kernel-obs.list
+        fi
 	sudo install -m644 etc/apt/trusted.gpg.d/* ${SYSIMAGE}/etc/apt/trusted.gpg.d/
 	sudo install etc/kernel/postinst.d/* ${SYSIMAGE}/etc/kernel/postinst.d/
 	sudo mkdir -p ${SYSIMAGE}/var/lib/alsa/


### PR DESCRIPTION
- Support `RELEASE=sid`.
- Fix the default mmc device under recent kernels.

I didn't update the README because I don't recommend unstable to non-expert users. Let me know if you'd rather it was kept consistent.