### PR TITLE
Use --depth 1 in submodule update

### DIFF
--- a/install-debian
+++ b/install-debian
@@ -30,7 +30,7 @@ on_target () {
 do_prep () {
 	printf '\n\n>>>> Preparing to install\n\n'
 
-	git submodule update --init
+	git submodule update --init --depth 1
 
 	PACKAGES="debootstrap pigz dosfstools"
 	[ ! -z "$CRYPT" ] && PACKAGES="$PACKAGES cryptsetup"


### PR DESCRIPTION
There's no real need to pull in the whole version history for submodules I think, and it's quite a lot quicker. I am running this from debian on the SD card of my pinebook, installing to the EMMC :)