### PR TITLE
Clarify filesystem encryption support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ environment.
    volume is which. If not supplied defaults to the basename of
    `BLKDEV` (e.g.  `mmcblk1`).
  * `CRYPT=y` - Encrypt the filesystem (and swap space) using LUKS. This
-   requires your kernel to support filesystem encryption. The original
-   factory distro did not include this feature so it it not possible to
-   install a LUKS filesystem from this distro. However you can make a
+   requires your kernel to support filesystem encryption.
+   If `zgrep CONFIG_DM_CRYPT /proc/config.gz` returns `CONFIG_DM_CRYPT=m`,
+   you are good to go. If not, you will need to update your kernel
+   to version 4.4.210 or later. Alternatively, you can make a
    temporary unencrypted install with this installer and then use the
    temporary OS to perform a full encrypted install.
  * `DRYRUN=y` - Show the commands the installer would "like" to run but


### PR DESCRIPTION
Closes daniel-thompson/pinebook-pro-debian-installer#13.
As per the discussion, kernel version >= 4.4.210 is sufficient
for filesystem encryption support (`CONFIG_DM_CRYPT=m`).
I am submitting this very pull request from such an installation.
See <http://students.engr.scu.edu/~sschaeck/misc/pinebookpro-config-4.4.210.txt>.
Archived version: <https://web.archive.org/web/20201219161431/http://students.engr.scu.edu/~sschaeck/misc/pinebookpro-config-4.4.210.txt>